### PR TITLE
move __n closer to feature parity with i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _pluralization support:_
 ```js
 var __n = require('y18n').__n
 
-console.log(__('%s fish %s', '%s fishes %s', 2, 2, 'foo'))
+console.log(__('one fish %s', '%d fishes %s', 2, 'foo'))
 ```
 
 output:
@@ -59,7 +59,8 @@ Print a localized string, `%s` will be replaced with `arg`s.
 
 ### y18n.\_\_n(singularString, pluralString, count, arg, arg, arg)
 
-Print a localized string with appropriate pluralization.
+Print a localized string with appropriate pluralization. If `%d` is provided
+in the string, the `count` will replace this placeholder.
 
 ### y18n.setLocale(str)
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,12 @@ Y18N.prototype.__n = function () {
     cb()
   }
 
-  return util.format.apply(util, [str].concat(args))
+  // if a %d placeholder is provided, add quantity
+  // to the arguments expanded by util.format.
+  var values = [str]
+  if (~str.indexOf('%d')) values.push(quantity)
+
+  return util.format.apply(util, values.concat(args))
 }
 
 Y18N.prototype.setLocale = function (locale) {

--- a/test/locales/en.json
+++ b/test/locales/en.json
@@ -1,12 +1,16 @@
 {
   "Hello": "Hello!",
   "Hello %s %s": "Hello %s %s",
-  "%s cat": {
-    "one": "%s cat",
-    "other": "%s cats"
+  "%d cat": {
+    "one": "%d cat",
+    "other": "%d cats"
   },
-  "%s %s cat": {
-    "one": "%s %s cat",
-    "other": "%s %s cats"
+  "%d %s cat": {
+    "one": "%d %s cat",
+    "other": "%d %s cats"
+  },
+  "There is one monkey in the %s": {
+    "one": "There is one monkey in the %s",
+    "other": "There are %d monkeys in the %s"
   }
 }

--- a/test/locales/pirate.json
+++ b/test/locales/pirate.json
@@ -1,7 +1,7 @@
 {
   "Hello": "Avast ye mateys!",
-  "%s cat": {
-    "one": "%s land catfish",
-    "other": "%s land catfishes"
+  "%d cat": {
+    "one": "%d land catfish",
+    "other": "%d land catfishes"
   }
 }

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -124,7 +124,7 @@ describe('y18n', function () {
         directory: __dirname + '/locales'
       }).__n
 
-      __n('%s cat', '%s cats', 1, 1).should.equal('1 cat')
+      __n('%d cat', '%d cats', 1).should.equal('1 cat')
     })
 
     it('uses the plural form if quantity is greater than 1', function () {
@@ -132,7 +132,7 @@ describe('y18n', function () {
         directory: __dirname + '/locales'
       }).__n
 
-      __n('%s cat', '%s cats', 2, 2).should.equal('2 cats')
+      __n('%d cat', '%d cats', 2).should.equal('2 cats')
     })
 
     it('allows additional arguments to be printed', function () {
@@ -140,7 +140,7 @@ describe('y18n', function () {
         directory: __dirname + '/locales'
       }).__n
 
-      __n('%s %s cat', '%s %s cats', 2, 2, 'black').should.equal('2 black cats')
+      __n('%d %s cat', '%d %s cats', 2, 'black').should.equal('2 black cats')
     })
 
     it('allows an alternative locale to be set', function () {
@@ -149,8 +149,21 @@ describe('y18n', function () {
         directory: __dirname + '/locales'
       }).__n
 
-      __n('%s cat', '%s cats', 1, 1).should.equal('1 land catfish')
-      __n('%s cat', '%s cats', 3, 3).should.equal('3 land catfishes')
+      __n('%d cat', '%d cats', 1).should.equal('1 land catfish')
+      __n('%d cat', '%d cats', 3).should.equal('3 land catfishes')
+    })
+
+    // See: https://github.com/bcoe/yargs/pull/210
+    it('allows a quantity placeholder to be provided in the plural but not singular form', function () {
+      var __n = y18n({
+        directory: __dirname + '/locales'
+      }).__n
+
+      var singular = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 1, 'tree')
+      var plural = __n('There is one monkey in the %s', 'There are %d monkeys in the %s', 3, 'tree')
+
+      singular.should.equal('There is one monkey in the tree')
+      plural.should.equal('There are 3 monkeys in the tree')
     })
 
     describe('the first time observing a pluralization', function () {
@@ -166,7 +179,7 @@ describe('y18n', function () {
           directory: __dirname + '/locales'
         }).__n
 
-        __n('%s le cat', '%s le cats', 1, 1).should.equal('1 le cat')
+        __n('%d le cat', '%d le cats', 1).should.equal('1 le cat')
       })
 
       it('writes to the locale file if updateFiles is true', function (done) {
@@ -175,10 +188,10 @@ describe('y18n', function () {
           directory: __dirname + '/locales'
         }).__n
 
-        __n('%s apple %s', '%s apples %s', 2, 'dude', function (err) {
+        __n('%d apple %s', '%d apples %s', 2, 'dude', function (err) {
           var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
-          locale['%s apple %s'].one.should.equal('%s apple %s')
-          locale['%s apple %s'].other.should.equal('%s apples %s')
+          locale['%d apple %s'].one.should.equal('%d apple %s')
+          locale['%d apple %s'].other.should.equal('%d apples %s')
           return done(err)
         })
       })
@@ -190,7 +203,7 @@ describe('y18n', function () {
           directory: __dirname + '/locales'
         }).__n
 
-        __n('%s apple %s', '%s apples %s', 2, 'dude', function (err) {
+        __n('%d apple %s', '%d apples %s', 2, 'dude', function (err) {
           fs.existsSync('./test/locales/fr.json').should.equal(false)
           return done(err)
         })


### PR DESCRIPTION
Based on [this discussion](https://github.com/bcoe/yargs/pull/210) with @nexdrew, I've made the string expansion a bit more clever. This brings us closer to feature parity with i18n:

***

Not sure if y18n is shooting for feature parity with [i18n](https://www.npmjs.com/package/i18n) or [i18n-2](https://www.npmjs.com/package/i18n-2) (excluding integration with express or templating libraries), but it currently doesn't handle the following "nested" usage of `__n` from their docs:

```js
var singular = i18n.__n('There is one monkey in the %%s', 'There are %d monkeys in the %%s', 1, 'tree');
var plural = i18n.__n('There is one monkey in the %%s', 'There are %d monkeys in the %%s', 3, 'tree');
console.log(singular); //There is one monkey in the tree
console.log(plural); //There are 3 monkeys in the tree
```

I assume the equivalent with y18n would be this:

```js
var singular = y18n.__n('There is one monkey in the %s', 'There are %s monkeys in the %s', 1, 1, 'tree');
var plural = y18n.__n('There is one monkey in the %s', 'There are %s monkeys in the %s', 3, 3, 'tree');
console.log(singular); //There is one monkey in the 1 tree => WHOOPS
console.log(plural); //There are 3 monkeys in the tree
```

The only way this seems to work with y18n (or with `util.format()` in general) is to know not to pass the first placeholder argument for the singular scenario:

```js
var singular = y18n.__n('There is one monkey in the %s', 'There are %d monkeys in the %s', 1, 'tree');
console.log(singular); //There is one monkey in the tree => BINGO
```

Again, not sure this is really an issue to care about, but it *is* a difference.