### PR TITLE
Fallback to language-only file if language_territory file DNE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Create an instance of y18n with the config provided, options include:
 * `directory`: the locale directory, default `./locales`.
 * `updateFiles`: should newly observed strings be updated in file, default `true`.
 * `locale`: what locale should be used.
+* `fallbackToLanguage`: should fallback to a language-only file (e.g. `en.json`)
+  be allowed if a file matching the locale does not exist (e.g. `en_US.json`),
+  default `true`.
 
 ### y18n.\_\_(str, arg, arg, arg)
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function Y18N (opts) {
   this.directory = opts.directory || './locales'
   this.updateFiles = typeof opts.updateFiles === 'boolean' ? opts.updateFiles : true
   this.locale = opts.locale || 'en'
+  this.fallbackToLanguage = typeof opts.fallbackToLanguage === 'boolean' ? opts.fallbackToLanguage : true
 
   // internal stuff.
   this.cache = {}
@@ -83,7 +84,7 @@ Y18N.prototype._readLocaleFile = function () {
 
 Y18N.prototype._resolveLocaleFile = function (directory, locale) {
   var file = path.resolve(directory, './', locale + '.json')
-  if (!this._fileExistsSync(file) && ~locale.lastIndexOf('_')) {
+  if (this.fallbackToLanguage && !this._fileExistsSync(file) && ~locale.lastIndexOf('_')) {
     // attempt fallback to language only
     var languageFile = path.resolve(directory, './', locale.split('_')[0] + '.json')
     if (this._fileExistsSync(languageFile)) file = languageFile

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ Y18N.prototype._processWriteQueue = function () {
   var locale = work[1]
   var cb = work[2]
 
-  var languageFile = path.resolve(directory, './', locale + '.json')
+  var languageFile = this._resolveLocaleFile(directory, locale)
   var serializedLocale = JSON.stringify(this.cache[locale], null, 2)
 
   fs.writeFile(languageFile, serializedLocale, 'utf-8', function (err) {
@@ -65,7 +65,7 @@ Y18N.prototype._processWriteQueue = function () {
 
 Y18N.prototype._readLocaleFile = function () {
   var localeLookup = {}
-  var languageFile = path.resolve(this.directory, './', this.locale + '.json')
+  var languageFile = this._resolveLocaleFile(this.directory, this.locale)
 
   try {
     localeLookup = JSON.parse(fs.readFileSync(languageFile, 'utf-8'))
@@ -79,6 +79,26 @@ Y18N.prototype._readLocaleFile = function () {
   }
 
   this.cache[this.locale] = localeLookup
+}
+
+Y18N.prototype._resolveLocaleFile = function (directory, locale) {
+  var file = path.resolve(directory, './', locale + '.json')
+  if (!this._fileExistsSync(file) && ~locale.lastIndexOf('_')) {
+    // attempt fallback to language only
+    var languageFile = path.resolve(directory, './', locale.split('_')[0] + '.json')
+    if (this._fileExistsSync(languageFile)) file = languageFile
+  }
+  return file
+}
+
+// this only exists because fs.existsSync() "will be deprecated"
+// see https://nodejs.org/api/fs.html#fs_fs_existssync_path
+Y18N.prototype._fileExistsSync = function (file) {
+  try {
+    return fs.statSync(file).isFile()
+  } catch (err) {
+    return false
+  }
 }
 
 Y18N.prototype.__n = function () {

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -129,7 +129,7 @@ describe('y18n', function () {
         })
       })
 
-      it('does not write new word to language file if fallbackToLanguage is false', function (done) {
+      it('writes word to missing locale file, if no fallback takes place', function (done) {
         fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
 
         var __ = y18n({

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -46,6 +46,25 @@ describe('y18n', function () {
       __('Hello').should.equal('Avast ye mateys!')
     })
 
+    it('uses language file if language_territory file does not exist', function () {
+      var __ = y18n({
+        locale: 'pirate_JM',
+        directory: __dirname + '/locales'
+      }).__
+
+      __('Hello').should.equal('Avast ye mateys!')
+    })
+
+    it('uses strings as given if no matching locale files found', function () {
+      var __ = y18n({
+        locale: 'zz_ZZ',
+        updateFiles: false,
+        directory: __dirname + '/locales'
+      }).__
+
+      __('Hello').should.equal('Hello')
+    })
+
     it('expands arguments into %s placeholders', function () {
       var __ = y18n({
         directory: __dirname + '/locales'
@@ -56,7 +75,7 @@ describe('y18n', function () {
 
     describe('the first time observing a word', function () {
       beforeEach(function (done) {
-        rimraf('./test/locales/fr.json', function () {
+        rimraf('./test/locales/fr*.json', function () {
           return done()
         })
       })
@@ -72,10 +91,26 @@ describe('y18n', function () {
 
       it('writes new word to locale file if updateFiles is true', function (done) {
         var __ = y18n({
-          locale: 'fr',
+          locale: 'fr_FR',
           directory: __dirname + '/locales'
         }).__
 
+        __('banana', function (err) {
+          var locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
+          locale.banana.should.equal('banana')
+          return done(err)
+        })
+      })
+
+      it('writes new word to language file if language_territory file does not exist', function (done) {
+        fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
+
+        var __ = y18n({
+          locale: 'fr_FR',
+          directory: __dirname + '/locales'
+        }).__
+
+        __('meow').should.equal('le meow')
         __('banana', function (err) {
           var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
           locale.banana.should.equal('banana')

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -55,6 +55,17 @@ describe('y18n', function () {
       __('Hello').should.equal('Avast ye mateys!')
     })
 
+    it('does not fallback to language file if fallbackToLanguage is false', function () {
+      var __ = y18n({
+        locale: 'pirate_JM',
+        fallbackToLanguage: false,
+        updateFiles: false,
+        directory: __dirname + '/locales'
+      }).__
+
+      __('Hello').should.equal('Hello')
+    })
+
     it('uses strings as given if no matching locale files found', function () {
       var __ = y18n({
         locale: 'zz_ZZ',
@@ -114,6 +125,29 @@ describe('y18n', function () {
         __('banana', function (err) {
           var locale = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
           locale.banana.should.equal('banana')
+          return done(err)
+        })
+      })
+
+      it('does not write new word to language file if fallbackToLanguage is false', function (done) {
+        fs.writeFileSync('./test/locales/fr.json', '{"meow": "le meow"}', 'utf-8')
+
+        var __ = y18n({
+          locale: 'fr_FR',
+          fallbackToLanguage: false,
+          directory: __dirname + '/locales'
+        }).__
+
+        var frJson = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+        frJson.should.deep.equal({
+          meow: 'le meow'
+        })
+
+        __('banana', function (err) {
+          var locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
+          locale.should.deep.equal({
+            banana: 'banana'
+          })
           return done(err)
         })
       })

--- a/test/y18n-test.js
+++ b/test/y18n-test.js
@@ -138,15 +138,16 @@ describe('y18n', function () {
           directory: __dirname + '/locales'
         }).__
 
-        var frJson = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
-        frJson.should.deep.equal({
-          meow: 'le meow'
-        })
-
         __('banana', function (err) {
+          // 'banana' should be written to fr_FR.json
           var locale = JSON.parse(fs.readFileSync('./test/locales/fr_FR.json', 'utf-8'))
           locale.should.deep.equal({
             banana: 'banana'
+          })
+          // fr.json should remain untouched
+          var frJson = JSON.parse(fs.readFileSync('./test/locales/fr.json', 'utf-8'))
+          frJson.should.deep.equal({
+            meow: 'le meow'
           })
           return done(err)
         })


### PR DESCRIPTION
Based on [yargs PR 231](https://github.com/bcoe/yargs/pull/231), attempt to better handle "full locales" (e.g. `en_US`) by allowing y18n to fallback to language-only file (e.g. `en.json`) if no file exists for the language_territory combination (e.g. `en_US.json`).

The [first commit](https://github.com/nexdrew/y18n/commit/099733dc40b6f45b741a12f003e5d93199d2664b) adds the initial implementation, which is, admittedly, not very efficient since it potentially adds 2 additional file system queries (`fs.statSync()`) per cached locale. Wasn't sure how to get around this without refactoring quite a bit of code. Note that I created a wrapper for `fs.statSync()` instead of just using `fs.existsSync()` directly since the latter is documented as "will be deprecated".

The [second commit](https://github.com/nexdrew/y18n/commit/50d0f0761d4709ed433bfc718d9d74bf866bb553) adds a new configuration option `fallbackToLanguage` so consumers can turn off this functionality if they don't like it. It's on by default, so that yargs can take advantage of it without any code changes. Not crazy about the config property name.

I'm also not especially crazy about splitting on `'_'` to splice out the language from the given locale value, but it should probably do for now.

Feedback welcomed!